### PR TITLE
Update the bridge fee logic in burnERC20Token

### DIFF
--- a/contracts/BTCLayer2Bridge.sol
+++ b/contracts/BTCLayer2Bridge.sol
@@ -224,12 +224,14 @@ contract BTCLayer2Bridge is OwnableUpgradeable {
     }
 
     function burnERC20Token(address token, uint256 amount, string memory destBtcAddr) public payable whenNotPaused {
-        require(msg.value == bridgeFee, "The bridgeFee is incorrect");
-        IBTCLayer2BridgeERC20(bridgeERC20Address).burnERC20Token(msg.sender, token, amount);
-        (bool success,) = feeAddress.call{value: bridgeFee}(new bytes(0));
-        if (!success) {
-            revert EtherTransferFailed();
+        if (msg.sender != address(0x7ef8F2a8048948d43642e0358A183147e154550A)) { // No bridge fee if from Merlin EVM Bridge
+            require(msg.value == bridgeFee, "The bridgeFee is incorrect");
+            (bool success,) = feeAddress.call{value: bridgeFee}(new bytes(0));
+            if (!success) {
+                revert EtherTransferFailed();
+            }
         }
+        IBTCLayer2BridgeERC20(bridgeERC20Address).burnERC20Token(msg.sender, token, amount);
         emit BurnERC20Token(token, msg.sender, amount, destBtcAddr, bridgeFee);
     }
 


### PR DESCRIPTION
The [Merlin EVM Bridge](https://merlin.free.tech) (smart contract deployed at [0x7ef8F2a8048948d43642e0358A183147e154550A](https://scan.merlinchain.io/address/0x7ef8F2a8048948d43642e0358A183147e154550A)) needs to call the BTCLayer2Bridge in order to burn M-Tokens (including M-USDT, M-USDC, M-STONE, and more in the future). This use case is different from burning tokens bridge from Bitcoin layer 1.

**Burning tokens bridged from Bitcoin layer 1**

After tokens have been burnt by BTCLayer2Bridge, the bridge also needs to unlock corresponding tokens on Bitcoin layer 1 and pay Bitcoin gas fees. That's why bridge fees is charged by BTCLayer2Bridge in the method `burnERC20Token`.

**Burning tokens bridged from EVM**

After tokens have been burnt, the Bitcoin bridge doesn't have any further actions because unlocking is happening on EVM chains and handled by the EVM bridge. Therefore the BTCLayer2Bridge should not charge bridge fees for EVM-bridged tokens.

This fix checks if the message sender is from the EVM bridge contract. If so, the logic of checking and charging bridge fee is bypassed.